### PR TITLE
move the GraphQL related code + deserialize JSON response to rust types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,19 +547,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.71"
+name = "powerfmt"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -614,7 +630,9 @@ dependencies = [
  "anyhow",
  "dotenv",
  "reqwest",
+ "serde",
  "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -670,18 +688,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -732,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.43"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -773,6 +791,35 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "time"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,6 @@ edition = "2021"
 anyhow = "1.0.77"
 dotenv = "0.15.0"
 reqwest = { version = "0.11.23", features = ["blocking", "json"] }
+serde = { version = "1.0.194", features = ["derive"] }
 serde_json = "1.0.108"
+time = { version = "0.3.31", features = ["serde-well-known"] }

--- a/src/github/graphql.rs
+++ b/src/github/graphql.rs
@@ -1,0 +1,296 @@
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use time::OffsetDateTime;
+
+/// Details on the endpoint can be found here
+/// <https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint>
+pub(crate) const GITHUB_GRAPHQL_URL: &str = "https://api.github.com/graphql";
+
+pub(crate) const GITHUB_REPOSITORY_QUERY: &str = "
+query GitHubRepositorySearch(
+  # The search string to look for. GitHub search syntax is supported.
+  $gitHubSearchString: String!
+  # Returns the first n elements from the list.
+  $limit: Int!
+  # Returns the elements in the list that come after the specified cursor.
+  # Check the `endCursor` on the returned pageInfo
+  $cursorOffset: String
+  # Ordering options for language connections.
+  $languageOrderBy: LanguageOrder!
+) {
+  search(first: $limit, after: $cursorOffset, query: $gitHubSearchString, type: REPOSITORY) {
+    repositoryCount
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      ... on Repository {
+        id
+        nameWithOwner
+        description
+        url
+        archivedAt
+        isFork
+        isLocked
+        pushedAt
+        updatedAt
+        languages(first: 5, orderBy: $languageOrderBy) {
+          totalCount
+          totalSize
+          edges {
+            size
+            node {
+              name
+            }
+          }
+        }
+        defaultBranchRef {
+          target {
+            oid
+          }
+        }
+      }
+    }
+  }
+}
+";
+
+pub(crate) fn github_repository_search_variables(
+    limit: usize,
+    cursor_offset: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
+      "gitHubSearchString": "language:rust topic:rust stars:>=50 template:false archived:false",
+      "limit": limit,
+      "cursorOffset": cursor_offset,
+      "languageOrderBy": {"field": "SIZE", "direction": "DESC"}
+    })
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GraphQLResponse<T> {
+    pub data: Option<T>,
+    pub error: Option<serde_json::Value>,
+}
+
+impl<T> GraphQLResponse<T>
+where
+    T: DeserializeOwned,
+{
+    pub fn new(source: String) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(&source)
+    }
+}
+
+/// Information about pagination in a connection.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PageInfo {
+    /// When paginating forwards, are there more items?
+    #[allow(unused)]
+    // FIXME(ytmimi): remove #[allow(unused)] after I add pagination support.
+    has_next_page: bool,
+    /// When paginating forwards, the cursor to continue
+    #[allow(unused)]
+    // FIXME(ytmimi): remove #[allow(unused)] after I add pagination support.
+    end_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubSearchResult {
+    search: GitHubSearchResultInner,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubSearchResultInner {
+    /// The total number of repositories that matched the search query
+    repository_count: usize,
+    /// Information to aid in pagination.
+    #[allow(unused)]
+    // FIXME(ytmimi): remove #[allow(unused)] after I add pagination support.
+    page_info: PageInfo,
+    #[serde(rename = "nodes")]
+    /// A list of repositories
+    repositories: Vec<RepositoryInfo>,
+}
+
+impl GitHubSearchResult {
+    /// The total number of repositories that met the search critera.
+    pub fn total_repository_count(&self) -> usize {
+        self.search.repository_count
+    }
+
+    /// All the repositories returned in this page of data.
+    pub fn repositories(&self) -> &[RepositoryInfo] {
+        &self.search.repositories
+    }
+
+    /// Token for the next page of data if it exists.
+    #[allow(unused)]
+    // FIXME(ytmimi): remove #[allow(unused)] after I add pagination support.
+    fn next_page(&self) -> Option<&str> {
+        self.search.page_info.end_cursor.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RepositoryInfo {
+    /// The Node ID of the Repository object.
+    /// The [ID] represents a unique identifier that is Base64 obfuscated
+    ///
+    /// [ID]: https://docs.github.com/en/graphql/reference/scalars#id
+    id: String,
+    /// The repository's name with owner.
+    name_with_owner: String,
+    /// The description of the repository.
+    // FIXME(ytmimi) I eventualy plan to write this value to the database,
+    // but I don't need it no.
+    #[allow(unused)]
+    description: String,
+    /// Identifies the date and time when the repository was archived.
+    #[serde(with = "time::serde::iso8601::option")]
+    // FIXME(ytmimi) I eventualy plan to write this value to the database,
+    // but I don't need it no.
+    #[allow(unused)]
+    archived_at: Option<OffsetDateTime>,
+    /// Identifies if the repository is a fork.
+    // FIXME(ytmimi) I eventualy plan to write this value to the database,
+    // but I don't need it no.
+    #[allow(unused)]
+    is_fork: bool,
+    /// Indicates if the repository has been locked or not.
+    // FIXME(ytmimi) I eventualy plan to write this value to the database,
+    // but I don't need it no.
+    #[allow(unused)]
+    is_locked: bool,
+    /// Identifies the date and time when the repository was last pushed to.
+    #[serde(with = "time::serde::iso8601")]
+    pushed_at: OffsetDateTime,
+    /// Identifies the date and time when the object was last updated.
+    #[serde(with = "time::serde::iso8601")]
+    updated_at: OffsetDateTime,
+    /// A list containing a breakdown of the language composition of the repository.
+    languages: Languages,
+    /// The Ref associated with the repository's default branch.
+    default_branch_ref: GitBranchRef,
+}
+
+impl RepositoryInfo {
+    /// Get the GitHub GraphQL ID for this repository
+    pub fn id(&self) -> &str {
+        self.id.as_str()
+    }
+
+    /// Get the name of the repostor with the owner included.
+    pub fn name_with_owner(&self) -> &str {
+        self.name_with_owner.as_str()
+    }
+
+    /// Provides an iterator over the languages in this git repository
+    pub fn languages<'a>(&'a self) -> LanguageIterator<impl Iterator<Item = &'a LanguageNode>> {
+        LanguageIterator {
+            total_size: self.languages.total_size,
+            inner: self.languages.edges.iter(),
+        }
+    }
+
+    /// How much of this repository was written in Rust
+    pub fn percent_of_code_in_rust(&self) -> f64 {
+        self.languages()
+            .filter(|programming_language| programming_language.name() == "Rust")
+            .next()
+            .map_or(0.0, |programming_language| {
+                programming_language.percent_of_code_in_repo()
+            })
+    }
+
+    /// Returns a reference to the latest commit hash fetched from GitHub
+    pub fn commit_hash(&self) -> &str {
+        &self.default_branch_ref.target.oid
+    }
+
+    /// The last time that the repository was pushe
+    pub fn pushed_at(&self) -> OffsetDateTime {
+        self.pushed_at
+    }
+
+    /// The last time that the repository was pushe
+    pub fn updated_at(&self) -> OffsetDateTime {
+        self.updated_at
+    }
+}
+
+/// A list of languages associated with the Repository.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Languages {
+    /// Identifies the total number of of languages found in a repository
+    #[allow(unused)]
+    total_count: usize,
+    /// The total size in bytes of the repository
+    total_size: usize,
+    /// Represents the languages of a repository.
+    edges: Vec<LanguageNode>,
+}
+
+pub struct LanguageIterator<I> {
+    total_size: usize,
+    inner: I,
+}
+
+pub struct ProgramingLanguage<'a> {
+    percent_of_code_in_repo: f64,
+    name: &'a str,
+}
+
+impl<'a> ProgramingLanguage<'a> {
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn percent_of_code_in_repo(&self) -> f64 {
+        self.percent_of_code_in_repo
+    }
+}
+
+impl<'a, I> Iterator for LanguageIterator<I>
+where
+    I: Iterator<Item = &'a LanguageNode>,
+{
+    type Item = ProgramingLanguage<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|language_node| ProgramingLanguage {
+            percent_of_code_in_repo: ((language_node.size as f64) / (self.total_size as f64))
+                * 100f64,
+            name: &language_node.node.name,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LanguageNode {
+    /// The number of bytes of code written in the language.
+    size: usize,
+    node: LanguageName,
+}
+
+#[derive(Debug, Deserialize)]
+struct LanguageName {
+    /// The name of the current language.
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitBranchRef {
+    target: GitCommit,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitCommit {
+    oid: String,
+}


### PR DESCRIPTION
The hard coded GraphQL query was moved to the `graphql.rs` module, and the newly added rust types were also added to the `graphql.rs`. In order to deserialize into rust types we bring in `serde` and the `time` crates as dependencies.

The `main` entrypoint was modified to use the new deserialized JSON response.