### PR TITLE
Add a `min_stars` search filter

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -22,7 +22,7 @@ pub fn search_github_repositories(
     let body = serde_json::json!({
         "operationName": "GitHubRepositorySearch",
         "query": GITHUB_REPOSITORY_QUERY,
-        "variables": github_repository_search_variables(10, None)
+        "variables": github_repository_search_variables(10, None, None)
     });
 
     let resp = client

--- a/src/github/graphql.rs
+++ b/src/github/graphql.rs
@@ -59,9 +59,14 @@ query GitHubRepositorySearch(
 pub(crate) fn github_repository_search_variables(
     limit: usize,
     cursor_offset: Option<&str>,
+    min_stars: Option<usize>,
 ) -> serde_json::Value {
+    let search_str = format!(
+        "language:rust topic:rust stars:>={} template:false archived:false",
+        min_stars.unwrap_or(50)
+    );
     serde_json::json!({
-      "gitHubSearchString": "language:rust topic:rust stars:>=50 template:false archived:false",
+      "gitHubSearchString": search_str,
       "limit": limit,
       "cursorOffset": cursor_offset,
       "languageOrderBy": {"field": "SIZE", "direction": "DESC"}


### PR DESCRIPTION
It's not being used yet, but it'll allow me to easily configure the min stars a repo should have when making requests to GitHub.   