### PR TITLE
Encapsulate RepositoryInfo behind Repository struct 

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1,5 +1,72 @@
 mod graphql;
 mod search;
+use graphql::RepositoryInfo as GraphQLRepoInfo;
 
-pub use graphql::{ProgrammingLanguage, RepositoryInfo};
+pub use graphql::ProgrammingLanguage;
 pub use search::{GitHubRepoSearch, RepoSearchResults};
+
+pub struct Repository {
+    inner: RepositoryInner,
+}
+
+impl From<GraphQLRepoInfo> for Repository {
+    fn from(value: GraphQLRepoInfo) -> Self {
+        Repository {
+            inner: RepositoryInner::GitHub(value),
+        }
+    }
+}
+
+enum RepositoryInner {
+    GitHub(GraphQLRepoInfo),
+}
+
+impl Repository {
+    pub fn id(&self) -> &str {
+        match &self.inner {
+            RepositoryInner::GitHub(repo) => repo.id(),
+        }
+    }
+
+    pub fn name_with_owner(&self) -> &str {
+        match &self.inner {
+            RepositoryInner::GitHub(repo) => repo.name_with_owner(),
+        }
+    }
+
+    pub fn url(&self) -> &str {
+        match &self.inner {
+            RepositoryInner::GitHub(repo) => repo.url(),
+        }
+    }
+
+    pub fn git_url(&self) -> &str {
+        match &self.inner {
+            RepositoryInner::GitHub(repo) => repo.git_url(),
+        }
+    }
+
+    pub fn percent_of_code_in_rust(&self) -> f64 {
+        match &self.inner {
+            RepositoryInner::GitHub(repo) => repo.percent_of_code_in_rust(),
+        }
+    }
+
+    pub fn commit_hash(&self) -> &str {
+        match &self.inner {
+            RepositoryInner::GitHub(repo) => repo.commit_hash(),
+        }
+    }
+
+    pub fn pushed_at(&self) -> time::OffsetDateTime {
+        match &self.inner {
+            RepositoryInner::GitHub(repo) => repo.pushed_at(),
+        }
+    }
+
+    pub fn updated_at(&self) -> time::OffsetDateTime {
+        match &self.inner {
+            RepositoryInner::GitHub(repo) => repo.updated_at(),
+        }
+    }
+}

--- a/src/github/graphql.rs
+++ b/src/github/graphql.rs
@@ -189,13 +189,14 @@ pub struct RepositoryInfo {
 }
 
 fn deserialize_git_url<'de, D>(data: D) -> Result<String, D::Error>
-where D: Deserializer<'de>
+where
+    D: Deserializer<'de>,
 {
     let mut url = String::deserialize(data)?;
     if !url.ends_with(".git") {
         url.push_str(".git");
     }
-    return Ok(url)
+    Ok(url)
 }
 
 impl RepositoryInfo {
@@ -235,8 +236,7 @@ impl RepositoryInfo {
     /// How much of this repository was written in Rust.
     pub fn percent_of_code_in_rust(&self) -> f64 {
         self.languages()
-            .filter(|programming_language| programming_language.name() == "Rust")
-            .next()
+            .find(|programming_language| programming_language.name() == "Rust")
             .map_or(0.0, |programming_language| {
                 programming_language.percent_of_code_in_repo()
             })

--- a/src/github/search.rs
+++ b/src/github/search.rs
@@ -154,7 +154,7 @@ impl RepoSearchResults {
             .and_then(|resp| resp.text())
             .map_err(|err| {
                 tracing::error!(?err);
-                return err;
+                err
             })
             .ok()?;
 

--- a/src/github/search.rs
+++ b/src/github/search.rs
@@ -1,7 +1,8 @@
 use super::graphql::{
-    github_repository_search_variables, GitHubSearchResult, GraphQLResponse, RepositoryInfo,
-    GITHUB_GRAPHQL_URL, GITHUB_REPOSITORY_QUERY,
+    github_repository_search_variables, GitHubSearchResult, GraphQLResponse, GITHUB_GRAPHQL_URL,
+    GITHUB_REPOSITORY_QUERY,
 };
+use super::Repository;
 use reqwest::header;
 use std::collections::VecDeque;
 
@@ -94,7 +95,7 @@ impl<'a> GitHubRepoSearch<'a> {
 }
 
 impl<'a> IntoIterator for GitHubRepoSearch<'a> {
-    type Item = RepositoryInfo;
+    type Item = Repository;
     type IntoIter = RepoSearchResults;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -112,7 +113,7 @@ pub struct RepoSearchResults {
     limit: usize,
     successful_requests_made: usize,
     max_requests: Option<usize>,
-    buffered_repos: VecDeque<RepositoryInfo>,
+    buffered_repos: VecDeque<Repository>,
 }
 
 impl RepoSearchResults {
@@ -129,7 +130,7 @@ impl RepoSearchResults {
     /// [get_next_page](RepoSearchResults::get_next_page) will stop returning results once the
     /// max_requests pages have been returned. The number of pages one is allowed to request
     /// can be configured using [max_pages](GitHubRepoSearch::max_pages)
-    pub fn get_next_page(&mut self) -> Option<Vec<RepositoryInfo>> {
+    pub fn get_next_page(&mut self) -> Option<Vec<Repository>> {
         if let Some(max_requests) = self.max_requests {
             if max_requests <= self.successful_requests_made {
                 return None;
@@ -186,7 +187,7 @@ impl RepoSearchResults {
 }
 
 impl Iterator for RepoSearchResults {
-    type Item = RepositoryInfo;
+    type Item = Repository;
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(repo_info) = self.buffered_repos.pop_front() {
             return Some(repo_info);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 mod github;
 
-pub use github::{GitHubRepoSearch, ProgrammingLanguage, RepoSearchResults, RepositoryInfo};
+pub use github::{GitHubRepoSearch, ProgrammingLanguage, RepoSearchResults, Repository};


### PR DESCRIPTION
This is more of a forward looking change. In the future I plan to store and retrieve repository info from a database. I wanted to provide a unified  interface for interacting with the underlying data without exposing the underlying types. I thought about using traits, however that would have complicated things because I'd need to box trait objects. Overall I think using an enum instead works pretty well.